### PR TITLE
Custom day builder

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,10 +49,8 @@ class CalendarViewApp extends StatelessWidget {
                 isExpandable: true,
                 dayBuilder: (
                   BuildContext context,
-                  DateTime day, {
-                  bool isExpanded,
-                  DateTime selectedDate,
-                }) {
+                  DateTime day,
+                ) {
                   return new InkWell(
                     onTap: () => print(day),
                     child: new Container(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -48,7 +48,7 @@ class CalendarViewApp extends StatelessWidget {
                 onSelectedRangeChange: (range) => print(range),
                 isExpandable: true,
                 dayBuilder:
-                    (BuildContext context, DateTime day, bool isExpanded) {
+                    (BuildContext context, DateTime day, {bool isExpanded, DateTime selectedDate,}) {
                   return new InkWell(
                     onTap: () => print(day),
                     child: new Container(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,8 @@ class CalendarViewApp extends StatelessWidget {
               new Calendar(
                 onSelectedRangeChange: (range) => print(range),
                 isExpandable: true,
-                dayBuilder: (BuildContext context, DateTime day) {
+                dayBuilder:
+                    (BuildContext context, DateTime day, bool isExpanded) {
                   return new InkWell(
                     onTap: () => print(day),
                     child: new Container(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,8 +47,12 @@ class CalendarViewApp extends StatelessWidget {
               new Calendar(
                 onSelectedRangeChange: (range) => print(range),
                 isExpandable: true,
-                dayBuilder:
-                    (BuildContext context, DateTime day, {bool isExpanded, DateTime selectedDate,}) {
+                dayBuilder: (
+                  BuildContext context,
+                  DateTime day, {
+                  bool isExpanded,
+                  DateTime selectedDate,
+                }) {
                   return new InkWell(
                     onTap: () => print(day),
                     child: new Container(

--- a/lib/calendar_tile.dart
+++ b/lib/calendar_tile.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:date_utils/date_utils.dart';
+import 'package:flutter/material.dart';
 
 class CalendarTile extends StatelessWidget {
   final VoidCallback onDateSelected;

--- a/lib/calendar_tile.dart
+++ b/lib/calendar_tile.dart
@@ -59,11 +59,6 @@ class CalendarTile extends StatelessWidget {
     if (child != null) {
       return child;
     }
-    return new Container(
-      decoration: new BoxDecoration(
-        color: Colors.white,
-      ),
-      child: renderDateOrDayOfWeek(context),
-    );
+    return renderDateOrDayOfWeek(context);
   }
 }

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -165,7 +165,6 @@ class _CalendarState extends State<Calendar> {
           dateStyles: configureDateStyle(monthStarted, monthEnded),
           isSelected: Utils.isSameDay(selectedDate, day),
         );
-
         if (this.widget.dayBuilder != null) {
           dayWidgets.add(
             new Stack(

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -11,6 +11,7 @@ class Calendar extends StatefulWidget {
   final ValueChanged<DateTime> onDateSelected;
   final ValueChanged<Tuple2<DateTime, DateTime>> onSelectedRangeChange;
   final bool isExpandable;
+  final bool isExpanded;
   final DayBuilder dayBuilder;
   final bool showChevronsToChangeRange;
   final bool showTodayAction;
@@ -20,6 +21,7 @@ class Calendar extends StatefulWidget {
     this.onDateSelected,
     this.onSelectedRangeChange,
     this.isExpandable: false,
+    this.isExpanded: false,
     this.dayBuilder,
     this.showTodayAction: true,
     this.showChevronsToChangeRange: true,
@@ -38,13 +40,14 @@ class _CalendarState extends State<Calendar> {
   DateTime _selectedDate;
   Tuple2<DateTime, DateTime> selectedRange;
   String currentMonth;
-  bool isExpanded = false;
+  bool isExpanded;
   String displayMonth;
 
   DateTime get selectedDate => _selectedDate;
 
   void initState() {
     super.initState();
+    isExpanded = widget.isExpanded == true;
     selectedMonthsDays = Utils.daysInMonth(today);
     var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
     var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -169,8 +169,8 @@ class _CalendarState extends State<Calendar> {
           dayWidgets.add(
             new Stack(
               children: <Widget>[
-                widget.dayBuilder(context, day),
                 tile,
+                widget.dayBuilder(context, day),
               ],
             ),
           );

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -266,7 +266,7 @@ class _CalendarState extends State<Calendar> {
       var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(today);
     });
   }
 
@@ -277,7 +277,7 @@ class _CalendarState extends State<Calendar> {
       var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(today);
     });
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -1,15 +1,16 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
-import 'package:tuple/tuple.dart';
-import 'package:flutter_calendar/calendar_tile.dart';
 import 'package:date_utils/date_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_calendar/calendar_tile.dart';
+import 'package:tuple/tuple.dart';
 
 typedef DayBuilder(BuildContext context, DateTime day);
 
 class Calendar extends StatefulWidget {
   final ValueChanged<DateTime> onDateSelected;
   final ValueChanged<Tuple2<DateTime, DateTime>> onSelectedRangeChange;
+  final ValueChanged<bool> onExpanded;
   final bool isExpandable;
   final DayBuilder dayBuilder;
   final bool showChevronsToChangeRange;
@@ -19,6 +20,7 @@ class Calendar extends StatefulWidget {
   Calendar({
     this.onDateSelected,
     this.onSelectedRangeChange,
+    this.onExpanded,
     this.isExpandable: false,
     this.dayBuilder,
     this.showTodayAction: true,
@@ -311,12 +313,9 @@ class _CalendarState extends State<Calendar> {
       lastDate: new DateTime(2050),
     );
 
-
-
     if (selected != null) {
       var firstDayOfCurrentWeek = Utils.firstDayOfWeek(selected);
       var lastDayOfCurrentWeek = Utils.lastDayOfWeek(selected);
-
 
       setState(() {
         _selectedDate = selected;
@@ -361,6 +360,7 @@ class _CalendarState extends State<Calendar> {
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
+      if (widget.onExpanded != null) widget.onExpanded(isExpanded);
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -176,7 +176,12 @@ class _CalendarState extends State<Calendar> {
             ),
           );
         } else {
-          dayWidgets.add(tile);
+          dayWidgets.add(new Container(
+            decoration: new BoxDecoration(
+              color: Colors.white,
+            ),
+            child: tile,
+          ));
         }
       },
     );

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -170,8 +170,8 @@ class _CalendarState extends State<Calendar> {
           dayWidgets.add(
             new Stack(
               children: <Widget>[
-                tile,
                 widget.dayBuilder(context, day),
+                tile,
               ],
             ),
           );

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -165,6 +165,7 @@ class _CalendarState extends State<Calendar> {
           dateStyles: configureDateStyle(monthStarted, monthEnded),
           isSelected: Utils.isSameDay(selectedDate, day),
         );
+
         if (this.widget.dayBuilder != null) {
           dayWidgets.add(
             new Stack(

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -5,7 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_calendar/calendar_tile.dart';
 import 'package:tuple/tuple.dart';
 
-typedef DayBuilder(BuildContext context, DateTime day, bool isExpanded);
+typedef DayBuilder(BuildContext context, DateTime day,
+    {bool isExpanded, DateTime selectedDate});
 
 class Calendar extends StatefulWidget {
   final ValueChanged<DateTime> onDateSelected;
@@ -162,7 +163,12 @@ class _CalendarState extends State<Calendar> {
         if (this.widget.dayBuilder != null) {
           dayWidgets.add(
             new CalendarTile(
-              child: this.widget.dayBuilder(context, day, isExpanded),
+              child: this.widget.dayBuilder(
+                    context,
+                    day,
+                    isExpanded: isExpanded,
+                    selectedDate: selectedDate,
+                  ),
             ),
           );
         } else {

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -328,11 +328,11 @@ class _CalendarState extends State<Calendar> {
 
       setState(() {
         _selectedDate = selected;
-        _updateSelectedRange();
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
         displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
+        _updateSelectedRange();
       });
       if (widget.onDateSelected != null) {
         widget.onDateSelected(_selectedDate);

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -328,7 +328,7 @@ class _CalendarState extends State<Calendar> {
 
       setState(() {
         _selectedDate = selected;
-        _updateSelectedRangeFromSelectedDate();
+        _updateSelectedRange();
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
@@ -370,14 +370,14 @@ class _CalendarState extends State<Calendar> {
     }
   }
 
-  void _updateSelectedRangeFromSelectedDate() {
+  void _updateSelectedRange() {
     if (isExpanded) {
-      var firstDateOfNewMonth = Utils.firstDayOfMonth(_selectedDate);
-      var lastDateOfNewMonth = Utils.lastDayOfMonth(_selectedDate);
+      var firstDateOfNewMonth = Utils.firstDayOfMonth(today);
+      var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
     } else {
-      var firstDayOfCurrentWeek = Utils.firstDayOfWeek(_selectedDate);
-      var lastDayOfCurrentWeek = Utils.lastDayOfWeek(_selectedDate);
+      var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
+      var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);
       updateSelectedRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek);
     }
   }
@@ -385,7 +385,7 @@ class _CalendarState extends State<Calendar> {
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
-      _updateSelectedRangeFromSelectedDate();
+      _updateSelectedRange();
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -328,14 +328,16 @@ class _CalendarState extends State<Calendar> {
 
       setState(() {
         _selectedDate = selected;
+        _updateSelectedRange();
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
         displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
-        if (widget.onDateSelected != null) {
-          widget.onDateSelected(_selectedDate);
-        }
+
       });
+      if (widget.onDateSelected != null) {
+        widget.onDateSelected(_selectedDate);
+      }
     }
   }
 
@@ -369,18 +371,22 @@ class _CalendarState extends State<Calendar> {
     }
   }
 
+  void _updateSelectedRange() {
+    if (isExpanded) {
+      var firstDateOfNewMonth = Utils.firstDayOfMonth(today);
+      var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
+      updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
+    } else {
+      var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
+      var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);
+      updateSelectedRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek);
+    }
+  }
+
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
-      if (isExpanded) {
-        var firstDateOfNewMonth = Utils.firstDayOfMonth(today);
-        var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
-        updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
-      } else {
-        var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
-        var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);
-        updateSelectedRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek);
-      }
+      _updateSelectedRange();
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -361,6 +361,15 @@ class _CalendarState extends State<Calendar> {
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
+      if (isExpanded) {
+        var firstDateOfNewMonth = Utils.firstDayOfMonth(today);
+        var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
+        updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
+      } else {
+        var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
+        var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);
+        updateSelectedRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek);
+      }
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -332,6 +332,9 @@ class _CalendarState extends State<Calendar> {
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
         displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
+        if (widget.onDateSelected != null) {
+          widget.onDateSelected(_selectedDate);
+        }
       });
     }
   }

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -5,12 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_calendar/calendar_tile.dart';
 import 'package:tuple/tuple.dart';
 
-typedef DayBuilder(BuildContext context, DateTime day);
+typedef DayBuilder(BuildContext context, DateTime day, bool isExpanded);
 
 class Calendar extends StatefulWidget {
   final ValueChanged<DateTime> onDateSelected;
   final ValueChanged<Tuple2<DateTime, DateTime>> onSelectedRangeChange;
-  final ValueChanged<bool> onExpanded;
   final bool isExpandable;
   final DayBuilder dayBuilder;
   final bool showChevronsToChangeRange;
@@ -20,7 +19,6 @@ class Calendar extends StatefulWidget {
   Calendar({
     this.onDateSelected,
     this.onSelectedRangeChange,
-    this.onExpanded,
     this.isExpandable: false,
     this.dayBuilder,
     this.showTodayAction: true,
@@ -164,7 +162,7 @@ class _CalendarState extends State<Calendar> {
         if (this.widget.dayBuilder != null) {
           dayWidgets.add(
             new CalendarTile(
-              child: this.widget.dayBuilder(context, day),
+              child: this.widget.dayBuilder(context, day, isExpanded),
             ),
           );
         } else {
@@ -360,7 +358,6 @@ class _CalendarState extends State<Calendar> {
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
-      if (widget.onExpanded != null) widget.onExpanded(isExpanded);
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -255,6 +255,8 @@ class _CalendarState extends State<Calendar> {
           .toList();
       displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
     });
+    _updateSelectedRange();
+    if (widget.onDateSelected != null) widget.onDateSelected(_selectedDate);
   }
 
   void nextMonth() {

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -328,12 +328,11 @@ class _CalendarState extends State<Calendar> {
 
       setState(() {
         _selectedDate = selected;
-        _updateSelectedRange();
+        _updateSelectedRangeFromSelectedDate();
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
         displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
-
       });
       if (widget.onDateSelected != null) {
         widget.onDateSelected(_selectedDate);
@@ -371,14 +370,14 @@ class _CalendarState extends State<Calendar> {
     }
   }
 
-  void _updateSelectedRange() {
+  void _updateSelectedRangeFromSelectedDate() {
     if (isExpanded) {
-      var firstDateOfNewMonth = Utils.firstDayOfMonth(today);
-      var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
+      var firstDateOfNewMonth = Utils.firstDayOfMonth(_selectedDate);
+      var lastDateOfNewMonth = Utils.lastDayOfMonth(_selectedDate);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
     } else {
-      var firstDayOfCurrentWeek = Utils.firstDayOfWeek(today);
-      var lastDayOfCurrentWeek = Utils.lastDayOfWeek(today);
+      var firstDayOfCurrentWeek = Utils.firstDayOfWeek(_selectedDate);
+      var lastDayOfCurrentWeek = Utils.lastDayOfWeek(_selectedDate);
       updateSelectedRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek);
     }
   }
@@ -386,7 +385,7 @@ class _CalendarState extends State<Calendar> {
   void toggleExpanded() {
     if (widget.isExpandable) {
       setState(() => isExpanded = !isExpanded);
-      _updateSelectedRange();
+      _updateSelectedRangeFromSelectedDate();
     }
   }
 

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -5,8 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_calendar/calendar_tile.dart';
 import 'package:tuple/tuple.dart';
 
-typedef DayBuilder(BuildContext context, DateTime day,
-    {bool isExpanded, DateTime selectedDate});
+typedef DayBuilder(BuildContext context, DateTime day);
 
 class Calendar extends StatefulWidget {
   final ValueChanged<DateTime> onDateSelected;
@@ -160,26 +159,24 @@ class _CalendarState extends State<Calendar> {
           monthStarted = true;
         }
 
+        final tile = new CalendarTile(
+          onDateSelected: () => handleSelectedDateAndUserCallback(day),
+          date: day,
+          dateStyles: configureDateStyle(monthStarted, monthEnded),
+          isSelected: Utils.isSameDay(selectedDate, day),
+        );
+
         if (this.widget.dayBuilder != null) {
           dayWidgets.add(
-            new CalendarTile(
-              child: this.widget.dayBuilder(
-                    context,
-                    day,
-                    isExpanded: isExpanded,
-                    selectedDate: selectedDate,
-                  ),
+            new Stack(
+              children: <Widget>[
+                widget.dayBuilder(context, day),
+                tile,
+              ],
             ),
           );
         } else {
-          dayWidgets.add(
-            new CalendarTile(
-              onDateSelected: () => handleSelectedDateAndUserCallback(day),
-              date: day,
-              dateStyles: configureDateStyle(monthStarted, monthEnded),
-              isSelected: Utils.isSameDay(selectedDate, day),
-            ),
-          );
+          dayWidgets.add(tile);
         }
       },
     );


### PR DESCRIPTION
When I use this excellent `Calendar` widget, I have to modified custom `DayBuilder` provider to suite on my use case. Probably not be general, but it suites to use case like:

1. Since custom `DayBuilder` widget is stacked with default `DayBuilder`, user does not needed to render day. Use case will be just to show small dot or number. Also user does not need to provide `onDateSelected` callback.

2. Allow Calendar starts with month view. (Useful in tablet)

