### PR TITLE
Change calendar GridView childAspectRatio to 1.0

### DIFF
--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -121,7 +121,7 @@ class _CalendarState extends State<Calendar> {
         child: new GridView.count(
           shrinkWrap: true,
           crossAxisCount: 7,
-          childAspectRatio: 1.5,
+          childAspectRatio: 1.0,
           mainAxisSpacing: 0.0,
           padding: new EdgeInsets.only(bottom: 0.0),
           children: calendarBuilder(),


### PR DESCRIPTION
This fixes a weird behavior reported in #1 , where calendar could no longer be expanded.
A related issue is opened in Flutter repo: flutter/flutter#16125
So maybe the fix will come from Flutter itself. So feel free to close it if this is not applicable in this case.