### PR TITLE
fix for expanding month, as well as more consistent behavior on displayMonth

### DIFF
--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -57,7 +57,7 @@ class _CalendarState extends State<Calendar> {
         .toList()
         .sublist(0, 7);
     _selectedDate = today;
-    displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+    displayMonth = Utils.formatMonth(today);
   }
 
   Widget get nameAndIconRow {
@@ -125,7 +125,7 @@ class _CalendarState extends State<Calendar> {
         child: new GridView.count(
           shrinkWrap: true,
           crossAxisCount: 7,
-          childAspectRatio: 1.5,
+          childAspectRatio: 1.0,
           mainAxisSpacing: 0.0,
           padding: new EdgeInsets.only(bottom: 0.0),
           children: calendarBuilder(),
@@ -246,7 +246,7 @@ class _CalendarState extends State<Calendar> {
       selectedWeeksDays = Utils
           .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
           .toList();
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(today);
     });
 
     _launchDateSelectionCallback(today);
@@ -259,7 +259,7 @@ class _CalendarState extends State<Calendar> {
       var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(today);
     });
   }
 
@@ -270,7 +270,7 @@ class _CalendarState extends State<Calendar> {
       var lastDateOfNewMonth = Utils.lastDayOfMonth(today);
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(today);
     });
   }
 
@@ -284,7 +284,7 @@ class _CalendarState extends State<Calendar> {
           .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
           .toList()
           .sublist(0, 7);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(firstDayOfCurrentWeek);
     });
   }
 
@@ -298,7 +298,7 @@ class _CalendarState extends State<Calendar> {
           .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
           .toList()
           .sublist(0, 7);
-      displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(today));
+      displayMonth = Utils.formatMonth(lastDayOfCurrentWeek);
     });
   }
 
@@ -330,7 +330,7 @@ class _CalendarState extends State<Calendar> {
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
         selectedMonthsDays = Utils.daysInMonth(selected);
-        displayMonth = Utils.formatMonth(Utils.firstDayOfWeek(selected));
+        displayMonth = Utils.formatMonth(selected);
       });
 
       _launchDateSelectionCallback(selected);
@@ -382,6 +382,7 @@ class _CalendarState extends State<Calendar> {
           .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
           .toList();
       selectedMonthsDays = Utils.daysInMonth(day);
+      displayMonth = Utils.formatMonth(day);
     });
     _launchDateSelectionCallback(day);
   }


### PR DESCRIPTION
I noticed that displayMonth was behaving strangely when the selected date (ie today, August 2) was in a different month than the beginning of the week (today that would be last Sunday, July 29). The display at the top would always show the month corresponding to that Sunday, rather than the selected date. To fix this, I've changed displayMonth to generate off the selected date by default, or beginning/ends of week when using the next/previous week buttons.

The childAspectRatio change was something I took from a GitHub issue where the calendar would not expand, which was behavior I was seeing as well. I don't know is this is the ideal fix, but it does fix the issue in my project.