### PR TITLE
Apptree 8896

### DIFF
--- a/lib/calendar_tile.dart
+++ b/lib/calendar_tile.dart
@@ -57,7 +57,10 @@ class CalendarTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (child != null) {
-      return child;
+      return new InkWell(
+        child: child,
+        onTap: onDateSelected,
+      );
     }
     return new Container(
       decoration: new BoxDecoration(

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -160,6 +160,8 @@ class _CalendarState extends State<Calendar> {
           dayWidgets.add(
             new CalendarTile(
               child: this.widget.dayBuilder(context, day),
+              date: day,
+              onDateSelected: () => handleSelectedDateAndUserCallback(day),
             ),
           );
         } else {
@@ -278,6 +280,7 @@ class _CalendarState extends State<Calendar> {
               .sublist(0, 7);
       displayMonth = Utils.formatMonth(_selectedDate);
     });
+    _launchDateSelectionCallback(_selectedDate);
   }
 
   void previousWeek() {
@@ -292,6 +295,7 @@ class _CalendarState extends State<Calendar> {
               .sublist(0, 7);
       displayMonth = Utils.formatMonth(_selectedDate);
     });
+    _launchDateSelectionCallback(_selectedDate);
   }
 
   void updateSelectedRange(DateTime start, DateTime end) {
@@ -365,6 +369,7 @@ class _CalendarState extends State<Calendar> {
   }
 
   void handleSelectedDateAndUserCallback(DateTime day) {
+    print("Here");
     var firstDayOfCurrentWeek = Utils.firstDayOfWeek(day);
     var lastDayOfCurrentWeek = Utils.lastDayOfWeek(day);
     setState(() {

--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -369,7 +369,6 @@ class _CalendarState extends State<Calendar> {
   }
 
   void handleSelectedDateAndUserCallback(DateTime day) {
-    print("Here");
     var firstDayOfCurrentWeek = Utils.firstDayOfWeek(day);
     var lastDayOfCurrentWeek = Utils.lastDayOfWeek(day);
     setState(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_calendar
 description: A calendar widget that uses Material Design.
-version: 0.0.7
+version: 0.0.8
 author: Eric Windmill <ericwindmill.com>
 homepage: https://github.com/apptreesoftware/flutter_calendar
 


### PR DESCRIPTION
There was a bug where the flutter calendar didn't know about calendar updates if you passed in a day builder. 

This is fixed by returning Inkwell wrapping the child instead of the child and then handling the onTap method in the calendar. 