### PR TITLE
Allow changing date from parent widget

### DIFF
--- a/lib/flutter_calendar.dart
+++ b/lib/flutter_calendar.dart
@@ -42,17 +42,7 @@ class _CalendarState extends State<Calendar> {
   DateTime get selectedDate => _selectedDate;
 
   void initState() {
-    super.initState();
-    if (widget.initialCalendarDateOverride != null)
-      _selectedDate = widget.initialCalendarDateOverride;
-    selectedMonthsDays = Utils.daysInMonth(_selectedDate);
-    var firstDayOfCurrentWeek = Utils.firstDayOfWeek(_selectedDate);
-    var lastDayOfCurrentWeek = Utils.lastDayOfWeek(_selectedDate);
-    selectedWeeksDays =
-        Utils.daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
-            .toList()
-            .sublist(0, 7);
-    displayMonth = Utils.formatMonth(_selectedDate);
+    super.initState();    
   }
 
   Widget get nameAndIconRow {
@@ -225,6 +215,16 @@ class _CalendarState extends State<Calendar> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.initialCalendarDateOverride != null)
+      _selectedDate = widget.initialCalendarDateOverride;
+    selectedMonthsDays = Utils.daysInMonth(_selectedDate);
+    var firstDayOfCurrentWeek = Utils.firstDayOfWeek(_selectedDate);
+    var lastDayOfCurrentWeek = Utils.lastDayOfWeek(_selectedDate);
+    selectedWeeksDays =
+        Utils.daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
+            .toList()
+            .sublist(0, 7);
+    displayMonth = Utils.formatMonth(_selectedDate);
     return new Container(
       child: new Column(
         mainAxisAlignment: MainAxisAlignment.start,


### PR DESCRIPTION
Allow you to change the date from the parent widget and the Calendar will rebuild to the supplied date.  The existing parameter name `initialCalendarDateOverride` should probably be changed, but for backward compatibility I didn't make that change.